### PR TITLE
Fix: Centered footer content on mobile

### DIFF
--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -1,9 +1,9 @@
 .footer {
     @apply bg-black text-white py-6;
     .wrap {
-        @apply flex justify-between items-center;
+        @apply text-center flex flex-col gap-2 sm:gap-0 sm:text-left sm:flex-row sm:justify-between sm:items-center;
         img {
-            @apply h-6;
+            @apply mx-auto sm:mx-0 h-6;
         }
     }
 }

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -12,7 +12,7 @@ export default function Footer() {
     <footer className={styles.footer}>
       <Container classes={styles.wrap}>
         <div>
-          <p>date: {date}</p>
+          <p>{date}</p>
           <p>branch: {branch.name}</p>
         </div>
         <a


### PR DESCRIPTION
**Description**
- Removed label for date on footer
- Center aligned content in mobile 